### PR TITLE
make daily weapon stats available to everyone

### DIFF
--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/TwitchBotClient.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/TwitchBotClient.java
@@ -123,7 +123,7 @@ public class TwitchBotClient {
 
 			goLiveListener = client.getEventManager().onEvent(ChannelGoLiveEvent.class, event -> {
 				if (resultsExporter != null) {
-					Account account = accountRepository.findByTwitchUserId(event.getChannel().getId()).orElse(new Account());
+					Account account = accountRepository.findByTwitchUserId(event.getChannel().getId()).orElse(null);
 					resultsExporter.start(account);
 				}
 
@@ -132,7 +132,7 @@ public class TwitchBotClient {
 
 			goOfflineListener = client.getEventManager().onEvent(ChannelGoOfflineEvent.class, event -> {
 				if (resultsExporter != null) {
-					Account account = accountRepository.findByTwitchUserId(event.getChannel().getId()).orElse(new Account());
+					Account account = accountRepository.findByTwitchUserId(event.getChannel().getId()).orElse(null);
 					resultsExporter.stop(account);
 				}
 

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/DiscordAdministrationAction.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/DiscordAdministrationAction.java
@@ -160,9 +160,9 @@ public class DiscordAdministrationAction extends ChatAction {
 			Account account = accountRepository.findAll().stream()
 					.filter(Account::getIsMainAccount)
 					.findFirst()
-					.orElse(new Account());
+					.orElse(null);
 
-			if (!twitchBotClient.isLive(account.getTwitchUserId())) {
+			if (account != null && !twitchBotClient.isLive(account.getTwitchUserId())) {
 				twitchBotClient.setFakeDebug(true);
 				resultsExporter.start(account);
 			}
@@ -172,9 +172,9 @@ public class DiscordAdministrationAction extends ChatAction {
 			Account account = accountRepository.findAll().stream()
 					.filter(Account::getIsMainAccount)
 					.findFirst()
-					.orElse(new Account());
+					.orElse(null);
 
-			if (twitchBotClient.isLive(account.getTwitchUserId())) {
+			if (account != null && twitchBotClient.isLive(account.getTwitchUserId())) {
 				twitchBotClient.setFakeDebug(false);
 				resultsExporter.stop(account);
 			}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/ManageStatsToSendAction.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/ManageStatsToSendAction.java
@@ -58,7 +58,7 @@ public class ManageStatsToSendAction extends ChatAction {
 						accountRepository.save(account);
 
 						if (account.getShouldSendDailyStats()) {
-							sender.send("Alright, you'll receive weapon stats every day at 0:15 am!");
+							sender.send("Alright, you'll receive weapon stats every day at roughly 0:15 am!");
 						} else {
 							sender.send("Alright, I won't send you weapon stats once every day (anymore)!");
 						}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/ManageStatsToSendAction.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/ManageStatsToSendAction.java
@@ -1,0 +1,76 @@
+package tv.strohi.twitch.strohkoenigbot.chatbot.actions;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import tv.strohi.twitch.strohkoenigbot.chatbot.actions.supertype.ActionArgs;
+import tv.strohi.twitch.strohkoenigbot.chatbot.actions.supertype.ArgumentKey;
+import tv.strohi.twitch.strohkoenigbot.chatbot.actions.supertype.ChatAction;
+import tv.strohi.twitch.strohkoenigbot.chatbot.actions.supertype.TriggerReason;
+import tv.strohi.twitch.strohkoenigbot.chatbot.actions.util.TwitchDiscordMessageSender;
+import tv.strohi.twitch.strohkoenigbot.data.model.Account;
+import tv.strohi.twitch.strohkoenigbot.data.repository.AccountRepository;
+import tv.strohi.twitch.strohkoenigbot.utils.DiscordAccountLoader;
+
+import java.util.EnumSet;
+
+@Component
+public class ManageStatsToSendAction extends ChatAction {
+
+	@Override
+	public EnumSet<TriggerReason> getCauses() {
+		return EnumSet.of(TriggerReason.DiscordPrivateMessage);
+	}
+
+	private AccountRepository accountRepository;
+
+	@Autowired
+	public void setAccountRepository(AccountRepository accountRepository) {
+		this.accountRepository = accountRepository;
+	}
+
+	private DiscordAccountLoader discordAccountLoader;
+
+	@Autowired
+	public void setDiscordAccountLoader(DiscordAccountLoader discordAccountLoader) {
+		this.discordAccountLoader = discordAccountLoader;
+	}
+
+	@Override
+	protected void execute(ActionArgs args) {
+		TwitchDiscordMessageSender sender = args.getReplySender();
+
+		String message = (String) args.getArguments().getOrDefault(ArgumentKey.Message, null);
+		if (message == null) {
+			return;
+		}
+
+		message = message.toLowerCase().trim();
+
+		if (message.startsWith("!stats")) {
+			message = message.substring("!stats".length()).trim();
+
+			if (message.startsWith("weapons on") || message.startsWith("weapons off")) {
+				Account account = discordAccountLoader.loadAccount(Long.parseLong(args.getUserId()));
+
+				if (account.getSplatoonCookie() != null && !account.getSplatoonCookie().isBlank()) {
+					if (account.getTimezone() != null && !account.getTimezone().isBlank()) {
+						account.setShouldSendDailyStats(message.startsWith("weapons on"));
+						accountRepository.save(account);
+
+						if (account.getShouldSendDailyStats()) {
+							sender.send("Alright, you'll receive weapon stats every day at 0:15 am!");
+						} else {
+							sender.send("Alright, I won't send you weapon stats once every day (anymore)!");
+						}
+					} else {
+						sender.send("**ERROR** Please set your timezone by using `!timezone find` first!");
+					}
+				} else {
+					sender.send("**ERROR** Please set your splatoon cookie by using `!splatoon2 register` first!");
+				}
+			} else {
+				sender.send("Allowed commands:\n    - !stats weapons on\n    - !stats weapons off");
+			}
+		}
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/RandomWeaponAction.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/RandomWeaponAction.java
@@ -92,7 +92,7 @@ public class RandomWeaponAction extends ChatAction {
 						.replace(" ", "");
 
 				long number = Integer.parseInt(foundFilter.replace("<", "").replace(">", "").replace("=", ""));
-				String prefix = foundFilter.replaceAll("[0-9]*", "");
+				String prefix = foundFilter.replaceAll("\\d*", "");
 
 				List<Splatoon2WeaponStats> filteredWeaponStats;
 

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/RegisterSplatoonAccountAction.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/RegisterSplatoonAccountAction.java
@@ -1,0 +1,187 @@
+package tv.strohi.twitch.strohkoenigbot.chatbot.actions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import tv.strohi.twitch.strohkoenigbot.chatbot.actions.supertype.ActionArgs;
+import tv.strohi.twitch.strohkoenigbot.chatbot.actions.supertype.ArgumentKey;
+import tv.strohi.twitch.strohkoenigbot.chatbot.actions.supertype.ChatAction;
+import tv.strohi.twitch.strohkoenigbot.chatbot.actions.supertype.TriggerReason;
+import tv.strohi.twitch.strohkoenigbot.chatbot.actions.util.TwitchDiscordMessageSender;
+import tv.strohi.twitch.strohkoenigbot.data.model.Account;
+import tv.strohi.twitch.strohkoenigbot.data.repository.AccountRepository;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.AuthLinkCreator;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.Authenticator;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.results.StatsExporter;
+import tv.strohi.twitch.strohkoenigbot.utils.DiscordAccountLoader;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+@Component
+public class RegisterSplatoonAccountAction extends ChatAction {
+	private final Logger logger = LogManager.getLogger(this.getClass().getSimpleName());
+
+	private AccountRepository accountRepository;
+
+	@Autowired
+	public void setAccountRepository(AccountRepository accountRepository) {
+		this.accountRepository = accountRepository;
+	}
+
+	private DiscordAccountLoader accountLoader;
+
+	@Autowired
+	public void setAccountLoader(DiscordAccountLoader accountLoader) {
+		this.accountLoader = accountLoader;
+	}
+
+	private StatsExporter statsExporter;
+
+	@Autowired
+	public void setStatsExporter(StatsExporter statsExporter) {
+		this.statsExporter = statsExporter;
+	}
+
+	private final AuthLinkCreator authLinkCreator = new AuthLinkCreator();
+	private final Authenticator authenticator = new Authenticator();
+	private final Map<Long, Tuple<AuthLinkCreator.AuthParams, Instant>> paramsMap = new HashMap<>();
+
+	@Override
+	public EnumSet<TriggerReason> getCauses() {
+		return EnumSet.of(TriggerReason.DiscordPrivateMessage);
+	}
+
+	@Override
+	protected void execute(ActionArgs args) {
+		TwitchDiscordMessageSender sender = args.getReplySender();
+
+		String message = (String) args.getArguments().getOrDefault(ArgumentKey.Message, null);
+		if (message == null) {
+			return;
+		}
+
+		message = message.trim();
+
+		if (message.toLowerCase().startsWith("!splatoon")) {
+			message = message.substring("!splatoon".length()).trim();
+
+			Account account = accountLoader.loadAccount(Long.parseLong(args.getUserId()));
+
+			if (message.toLowerCase().startsWith("register")) {
+				logger.info("Register splatoon token has been called");
+
+				AuthLinkCreator.AuthParams params = authLinkCreator.generateAuthenticationParams();
+				String authUrl = authLinkCreator.buildAuthUrl(params).toString();
+
+				paramsMap.put(Long.parseLong(args.getUserId()), new Tuple<>(params, Instant.now().plus(5, ChronoUnit.MINUTES)));
+
+				sender.send("**There are two ways to connect your splatoon account with this bot**:\n\n" +
+						"1. By using the token generation method from frozenpandaman & NexusMine <https://github.com/frozenpandaman/splatnet2statink/>.\n" +
+						"	This method involves calling their servers. If you don't want non-Nintendo servers to be involved in the cookie generation, please use the other method.\n\n" +
+						"	Steps to use this method:\n" +
+						"	1. Navigate to this URL in your browser:\n" +
+						"" + authUrl + "\n" +
+						"	2. Log in to your Nintendo account.\n"+
+						"	3. do a **right click** on the \"Select this person\" button and copy the link address.\n"+
+						"	4. send me a direct message with the copied address **within five minutes** in this form:" +
+						"```!splatoon link COPIED_ADDRESS```" +
+						"	For example: `!splatoon link npf71b963...` (link is much longer)\n\n" +
+						"2. By using mitmproxy, instructions can be found here: <https://github.com/frozenpandaman/splatnet2statink/wiki/mitmproxy-instructions>.\n" +
+						"	1. After copying the cookie (xxxxx) in Step 7, send me the cookie via direct message.\n" +
+						"	2. Send the message in this form:" +
+						"```!splatoon cookie COPIED_COOKIE```" +
+						"	For example: `!splatoon cookie ac2f44d4a...` (cookie is much longer)");
+			} else if (message.toLowerCase().startsWith("link") && !(message = message.substring("link".length()).trim()).isBlank()) {
+				Tuple<AuthLinkCreator.AuthParams, Instant> params = paramsMap.getOrDefault(account.getDiscordId(), null);
+
+				if (params != null) {
+					if (Instant.now().isBefore(params.second)) {
+						try {
+							account = generateAndStoreSessionToken(account, params.first, message);
+							statsExporter.refreshStatsForAccount(account);
+
+							sender.send("I successfully connected your account.");
+						} catch (Exception ex) {
+							logger.error(ex);
+							sender.send("I could not connect your account. Please make sure you copied the correct link.");
+						}
+					} else {
+						sender.send("You didn't send the link in time. Please try again using **!splatoon register**.");
+					}
+				} else {
+					sender.send("Please generate a link by using **!splatoon register** first.");
+				}
+			} else if (message.toLowerCase().startsWith("cookie") && !(message = message.substring("cookie".length()).trim()).isBlank()) {
+				account.setSplatoonCookie(message);
+				account.setSplatoonCookieExpiresAt(Instant.now().plus(10, ChronoUnit.MINUTES));
+				account.setSplatoonSessionToken(null);
+				account.setSplatoonNickname(args.getUser());
+				account.setRateLimitNumber(new Random().nextInt(30));
+
+				account = accountRepository.save(account);
+
+				statsExporter.refreshStatsForAccount(account);
+
+				sender.send("I successfully connected your account.");
+			} else if (message.toLowerCase().startsWith("delete")) {
+				account.setSplatoonCookie(null);
+				account.setSplatoonCookieExpiresAt(null);
+				account.setSplatoonSessionToken(null);
+				account.setSplatoonNickname(args.getUser());
+
+				accountRepository.save(account);
+
+				sender.send("I successfully deleted the splatoon cookie for your account.");
+			} else {
+				sender.send("Allowed commands:\n    - !splatoon register\n    - !splatoon link\n    - !splatoon cookie\n    - !splatoon delete");
+			}
+		}
+	}
+
+	@NotNull
+	public Account generateAndStoreSessionToken(Account account, AuthLinkCreator.AuthParams params, String redirectLink) {
+		URI link = URI.create(redirectLink);
+		String session_token_code = getQueryMap(link.getFragment()).get("session_token_code");
+
+		account.setSplatoonSessionToken(authenticator.getSessionToken("71b963c1b7b6d119", session_token_code, params.getCodeVerifier()));
+		account.setSplatoonCookie(null);
+		account.setSplatoonCookieExpiresAt(null);
+		account.setSplatoonNickname(null);
+
+		account = accountRepository.save(account);
+		return account;
+	}
+
+	public Map<String, String> getQueryMap(String query) {
+		String[] params = query.split("&");
+
+		Map<String, String> map = new HashMap<>();
+
+		for (String param : params) {
+			String name = param.split("=")[0];
+			String value = param.split("=")[1];
+			map.put(name, value);
+		}
+
+		return map;
+	}
+
+	@Getter
+	@Setter
+	@AllArgsConstructor
+	private static class Tuple <T1, T2> {
+		private T1 first;
+		private T2 second;
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/RegisterSplatoonAccountAction.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/chatbot/actions/RegisterSplatoonAccountAction.java
@@ -73,8 +73,8 @@ public class RegisterSplatoonAccountAction extends ChatAction {
 
 		message = message.trim();
 
-		if (message.toLowerCase().startsWith("!splatoon")) {
-			message = message.substring("!splatoon".length()).trim();
+		if (message.toLowerCase().startsWith("!splatoon2")) {
+			message = message.substring("!splatoon2".length()).trim();
 
 			Account account = accountLoader.loadAccount(Long.parseLong(args.getUserId()));
 
@@ -95,13 +95,13 @@ public class RegisterSplatoonAccountAction extends ChatAction {
 						"	2. Log in to your Nintendo account.\n"+
 						"	3. do a **right click** on the \"Select this person\" button and copy the link address.\n"+
 						"	4. send me a direct message with the copied address **within five minutes** in this form:" +
-						"```!splatoon link COPIED_ADDRESS```" +
-						"	For example: `!splatoon link npf71b963...` (link is much longer)\n\n" +
+						"```!splatoon2 link COPIED_ADDRESS```" +
+						"	For example: `!splatoon2 link npf71b963...` (link is much longer)\n\n" +
 						"2. By using mitmproxy, instructions can be found here: <https://github.com/frozenpandaman/splatnet2statink/wiki/mitmproxy-instructions>.\n" +
 						"	1. After copying the cookie (xxxxx) in Step 7, send me the cookie via direct message.\n" +
 						"	2. Send the message in this form:" +
-						"```!splatoon cookie COPIED_COOKIE```" +
-						"	For example: `!splatoon cookie ac2f44d4a...` (cookie is much longer)");
+						"```!splatoon2 cookie COPIED_COOKIE```" +
+						"	For example: `!splatoon2 cookie ac2f44d4a...` (cookie is much longer)");
 			} else if (message.toLowerCase().startsWith("link") && !(message = message.substring("link".length()).trim()).isBlank()) {
 				Tuple<AuthLinkCreator.AuthParams, Instant> params = paramsMap.getOrDefault(account.getDiscordId(), null);
 
@@ -117,10 +117,10 @@ public class RegisterSplatoonAccountAction extends ChatAction {
 							sender.send("I could not connect your account. Please make sure you copied the correct link.");
 						}
 					} else {
-						sender.send("You didn't send the link in time. Please try again using **!splatoon register**.");
+						sender.send("You didn't send the link in time. Please try again using **!splatoon2 register**.");
 					}
 				} else {
-					sender.send("Please generate a link by using **!splatoon register** first.");
+					sender.send("Please generate a link by using **!splatoon2 register** first.");
 				}
 			} else if (message.toLowerCase().startsWith("cookie") && !(message = message.substring("cookie".length()).trim()).isBlank()) {
 				account.setSplatoonCookie(message);
@@ -144,7 +144,7 @@ public class RegisterSplatoonAccountAction extends ChatAction {
 
 				sender.send("I successfully deleted the splatoon cookie for your account.");
 			} else {
-				sender.send("Allowed commands:\n    - !splatoon register\n    - !splatoon link\n    - !splatoon cookie\n    - !splatoon delete");
+				sender.send("Allowed commands:\n    - !splatoon2 register\n    - !splatoon2 link\n    - !splatoon2 cookie\n    - !splatoon2 delete");
 			}
 		}
 	}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/data/model/Account.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/data/model/Account.java
@@ -25,11 +25,15 @@ public class Account {
 
 	private Instant splatoonCookieExpiresAt;
 
+	private String splatoonNickname;
+
+	private String splatoonSessionToken;
+
 	private Boolean isMainAccount = false;
 
 	private String timezone;
 
 	private Boolean shouldSendDailyStats;
 
-	private Integer currentStep;
+	private Integer rateLimitNumber;
 }

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/AccountAccessTokenRetriever.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/AccountAccessTokenRetriever.java
@@ -1,0 +1,55 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+
+public class AccountAccessTokenRetriever extends AuthenticatorBase {
+	public String getAccountAccessToken(String sessionToken) {
+		String address = accountsHost + "/connect/1.0.0/api/token";
+		URI uri = URI.create(address);
+
+		String body = "";
+		try {
+			body = mapper.writeValueAsString(new GetTokenBody(sessionToken));
+		} catch (JsonProcessingException e) {
+			// will never happen
+			e.printStackTrace();
+		}
+
+		HttpRequest request = HttpRequest.newBuilder()
+				.POST(HttpRequest.BodyPublishers.ofString(body))
+				.uri(uri)
+				.setHeader("User-Agent", "OnlineLounge/" + nsoAppVersion + " NASDKAPI Android")
+				.setHeader("Accept-Language", "en-US")
+				.setHeader("Content-Type", "application/json; charset=utf-8")
+				.setHeader("Accept", "application/json")
+				.setHeader("Accept-Encoding", "gzip")
+				.build();
+
+		AccessTokenResponse response = sendRequestAndParseGzippedJson(request, AccessTokenResponse.class);
+		return response != null ? response.access_token : null;
+	}
+
+	@Data
+	private static class GetTokenBody {
+		private final String client_id = "71b963c1b7b6d119";
+		private final String session_token;
+		private final String grant_type = "urn:ietf:params:oauth:grant-type:jwt-bearer-session-token";
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	private static class AccessTokenResponse {
+		private String token_type;
+		private int expires_in;
+		private String access_token;
+		private String id_token;
+		private String[] scope;
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/AuthLinkCreator.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/AuthLinkCreator.java
@@ -1,0 +1,101 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Random;
+
+public class AuthLinkCreator {
+	Random random = new Random();
+
+	private String generateRandom(int length) {
+		byte[] bytes = new byte[length];
+		random.nextBytes(bytes);
+		return Base64.getUrlEncoder().encodeToString(bytes);
+	}
+
+	private String calculateChallenge(String codeVerifier) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] encodedhash = digest.digest(codeVerifier.getBytes(StandardCharsets.UTF_8));
+			return Base64.getUrlEncoder().encodeToString(encodedhash);
+		} catch (NoSuchAlgorithmException e) {
+			// this will never happen.
+			return "";
+		}
+	}
+
+	public AuthParams generateAuthenticationParams() {
+		String state = generateRandom(36);
+		String codeVerifier = generateRandom(32).replace("=", "");
+		String codeChallenge = calculateChallenge(codeVerifier).replace("=", "");
+
+		return new AuthParams(state, codeVerifier, codeChallenge);
+	}
+
+	public URI buildAuthUrl(AuthParams params) {
+		try {
+			return new URI(String.format("https://accounts.nintendo.com/connect/1.0.0/authorize?%s", params.getAuthStringParams()));
+		} catch (Exception e) {
+			// this will never happen
+			return null;
+		}
+	}
+
+	public static class AuthParams {
+		final String redirectUri = "npf71b963c1b7b6d119%3A%2F%2Fauth&client_id=71b963c1b7b6d119";
+		final String scope = "openid+user+user.birthday+user.mii+user.screenName";
+		final String responseType = "session_token_code";
+		final String sessionTokenCodeChallengeMethod = "S256";
+		final String theme = "login_form";
+
+		String state;
+		String codeVerifier;
+		String codeChallenge;
+
+		public String getState() {
+			return state;
+		}
+
+		public String getCodeVerifier() {
+			return codeVerifier;
+		}
+
+		public String getCodeChallenge() {
+			return codeChallenge;
+		}
+
+		public AuthParams(String state, String codeVerifier, String codeChallenge) {
+			this.state = state;
+			this.codeVerifier = codeVerifier;
+			this.codeChallenge = codeChallenge;
+		}
+
+		public String getAuthStringParams() {
+
+			return String.format(
+					"state=%s&redirect_uri=%s&scope=%s&response_type=%s&session_token_code_challenge=%s&session_token_code_challenge_method=%s&theme=%s",
+					getEncoded(state),
+					redirectUri,
+					scope,
+					responseType,
+					getEncoded(codeChallenge),
+					sessionTokenCodeChallengeMethod,
+					theme
+			);
+		}
+
+		private String getEncoded(String value) {
+			try {
+				value = URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+			} catch (UnsupportedEncodingException e) {
+				// this will never happen
+			}
+			return value;
+		}
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/Authenticator.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/Authenticator.java
@@ -1,0 +1,90 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model.AuthenticationData;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model.FParamLoginResult;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model.UserInfo;
+
+import java.net.HttpCookie;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public class Authenticator {
+	private final Logger logger = LogManager.getLogger(this.getClass().getSimpleName());
+
+	private final SessionTokenRetriever sessionTokenRetriever = new SessionTokenRetriever();
+	private final AccountAccessTokenRetriever accountAccessTokenRetriever = new AccountAccessTokenRetriever();
+	private final UserInfoRetriever userInfoRetriever = new UserInfoRetriever();
+	private final FTokenRetriever fTokenRetriever = new FTokenRetriever();
+	private final SplatoonTokenRetriever splatoonTokenRetriever = new SplatoonTokenRetriever();
+	private final SplatoonCookieRetriever splatoonCookieRetriever = new SplatoonCookieRetriever();
+
+	public String getSessionToken(String clientId, String sessionTokenCode, String sessionTokenCodeVerifier) {
+		return sessionTokenRetriever.getSessionToken(clientId, sessionTokenCode, sessionTokenCodeVerifier);
+	}
+
+	public AuthenticationData getAccess(String clientId, String sessionTokenCode, String sessionTokenCodeVerifier) {
+		String sessionToken = sessionTokenRetriever.getSessionToken(clientId, sessionTokenCode, sessionTokenCodeVerifier);
+		return refreshAccess(sessionToken);
+	}
+
+	public AuthenticationData refreshAccess(String sessionToken) {
+		logger.info("refreshing cookie of session token: {}", sessionToken);
+
+		int now = (int) (new Date().getTime() / 1000);
+		String guid = UUID.randomUUID().toString();
+
+		String accountAccessToken = accountAccessTokenRetriever.getAccountAccessToken(sessionToken);
+		logger.info("accountAccessToken");
+		logger.info(accountAccessToken);
+
+		UserInfo userInfo = userInfoRetriever.getUserInfo(accountAccessToken);
+		logger.info("userInfo");
+		logger.info(userInfo);
+
+		FParamLoginResult fTokenNso = fTokenRetriever.getFToken(accountAccessToken, guid, now, "nso");
+		logger.info("fTokenNso");
+		logger.info(fTokenNso);
+
+
+		String gameWebToken = splatoonTokenRetriever.doSplatoonAppLogin(userInfo, fTokenNso);
+		logger.info("gameWebToken");
+		logger.info(gameWebToken);
+
+		FParamLoginResult fTokenApp = fTokenRetriever.getFToken(gameWebToken, guid, now, "app");
+		logger.info("fTokenApp");
+		logger.info(fTokenApp);
+
+
+		String splatoonAccessToken = splatoonTokenRetriever.getSplatoonAccessToken(gameWebToken, fTokenApp);
+		logger.info("splatoonAccessToken");
+		logger.info(splatoonAccessToken);
+
+		String splatoonCookie = splatoonCookieRetriever.getSplatoonCookie(splatoonAccessToken);
+		logger.info("splatoonCookie");
+		logger.info(splatoonCookie);
+
+
+		List<HttpCookie> cookies = HttpCookie.parse(splatoonCookie);
+		HttpCookie iksmSessionCookie = cookies.stream().findFirst().orElse(null);
+		logger.info("iksmSessionCookie");
+		logger.info(iksmSessionCookie);
+
+
+		if (iksmSessionCookie != null) {
+			logger.info("worked");
+			String value = iksmSessionCookie.getValue();
+			long cookieLifeDuration = iksmSessionCookie.getMaxAge() >= 0 ? iksmSessionCookie.getMaxAge() : 31536000L;
+
+			Instant expiresAt = Instant.now().plus(cookieLifeDuration, ChronoUnit.SECONDS);
+			return new AuthenticationData(userInfo.getNickname(), value, expiresAt, sessionToken);
+		} else {
+			logger.error("exepction");
+			throw new RuntimeException("Splatoon 2 cookie could not be loaded");
+		}
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/AuthenticatorBase.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/AuthenticatorBase.java
@@ -1,0 +1,95 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.zip.GZIPInputStream;
+
+public abstract class AuthenticatorBase {
+	private final Logger logger = LogManager.getLogger(this.getClass().getSimpleName());
+
+	protected static final String nsoAppVersion;
+	private static final String nsoAppFallbackVersion = "2.1.1";
+	private static final String nsoAppVersionHistoryUrl = "https://www.nintendo.co.jp/support/app/nintendo_switch_online_app/index.html";
+
+	protected final HttpClient client = HttpClient.newBuilder()
+			.version(HttpClient.Version.HTTP_2)
+			.build();
+	protected final String accountsHost = "https://accounts.nintendo.com";
+
+	protected final ObjectMapper mapper = new ObjectMapper();
+
+	static {
+		nsoAppVersion = loadCurrentAndroidAppVersion();
+	}
+
+	protected final <T> T sendRequestAndParseGzippedJson(HttpRequest request, Class<T> valueType) {
+		try {
+			logger.info("sending new request to '{}'", request.uri().toString());
+			logger.info(request);
+			HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+
+			logger.info("got response with status code {}:", response.statusCode());
+			logger.info(response);
+
+			if (response.statusCode() < 300) {
+				String body = new String(response.body());
+
+				if (response.headers().map().containsKey("Content-Encoding") && !response.headers().map().get("Content-Encoding").isEmpty() && "gzip".equals(response.headers().map().get("Content-Encoding").get(0))) {
+					body = new String(new GZIPInputStream(new ByteArrayInputStream(response.body())).readAllBytes());
+				}
+
+				logger.info("response body: '{}'", body);
+
+				return mapper.readValue(body, valueType);
+			}
+		} catch (IOException | InterruptedException e) {
+			logger.error("exception while sending request");
+			logger.error(e);
+		}
+
+		return null;
+	}
+
+	private static String loadCurrentAndroidAppVersion() {
+		String result = nsoAppFallbackVersion;
+
+		try {
+			HttpClient client = HttpClient.newHttpClient();
+			HttpRequest request = HttpRequest.newBuilder()
+					.uri(URI.create(nsoAppVersionHistoryUrl))
+					.GET() // GET is default
+					.build();
+
+			HttpResponse<String> response = client.send(request,
+					HttpResponse.BodyHandlers.ofString());
+
+			result = Arrays.stream(response.body().split("</span>"))
+					.filter(str -> str.contains("Ver."))
+					.map(str -> Arrays.stream(str.split("Ver\\."))
+							.reduce((first, second) -> second)
+							.orElse(null))
+					.filter(Objects::nonNull)
+					.map(str -> Arrays.stream(str.trim().split(" "))
+							.findFirst()
+							.orElse(null))
+					.filter(Objects::nonNull)
+					.map(String::trim)
+					.findFirst()
+					.orElse(nsoAppFallbackVersion);
+		} catch (InterruptedException | IOException e) {
+			e.printStackTrace();
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/FTokenRetriever.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/FTokenRetriever.java
@@ -1,0 +1,55 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model.FParamLoginResult;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+
+public class FTokenRetriever extends AuthenticatorBase {
+	private final String USER_AGENT = "stroh/1.0.0";
+
+	public FParamLoginResult getFToken(String accessToken, String guid, int now, String iid) {
+		String address = "https://flapg.com/ika2/api/login?public";
+
+		URI uri = URI.create(address);
+		String hash = getS2SApiHash(accessToken, String.format("%d", now));
+
+		HttpRequest request = HttpRequest.newBuilder()
+				.GET()
+				.uri(uri)
+				.setHeader("x-token", accessToken)
+				.setHeader("x-time", String.format("%d", now))
+				.setHeader("x-guid", guid)
+				.setHeader("x-hash", hash)
+				.setHeader("x-ver", "3")
+				.setHeader("x-iid", iid)
+				.build();
+
+		return sendRequestAndParseGzippedJson(request, FParamLoginResult.class);
+	}
+
+	private String getS2SApiHash(String accessToken, String timestamp) {
+		String address = "https://elifessler.com/s2s/api/gen2";
+
+		URI uri = URI.create(address);
+
+		HttpRequest request = HttpRequest.newBuilder()
+				.POST(HttpRequest.BodyPublishers.ofString(String.format("naIdToken=%s&timestamp=%s", accessToken, timestamp)))
+				.uri(uri)
+				.setHeader("User-Agent", USER_AGENT)
+				.build();
+
+		NaIdTokenResponse response = sendRequestAndParseGzippedJson(request, NaIdTokenResponse.class);
+		return response != null ? response.getHash() : "";
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	private static class NaIdTokenResponse {
+		private String hash;
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/SessionTokenRetriever.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/SessionTokenRetriever.java
@@ -1,0 +1,38 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+
+public class SessionTokenRetriever extends AuthenticatorBase {
+	public String getSessionToken(String clientId, String sessionTokenCode, String sessionTokenCodeVerifier) {
+		String address = accountsHost + "/connect/1.0.0/api/session_token";
+		String body = String.format("client_id=%s&session_token_code=%s&session_token_code_verifier=%s", clientId, sessionTokenCode, sessionTokenCodeVerifier);
+
+		URI uri = URI.create(address);
+
+		HttpRequest request = HttpRequest.newBuilder()
+				.POST(HttpRequest.BodyPublishers.ofString(body))
+				.uri(uri)
+				.setHeader("User-Agent", "OnlineLounge/" + nsoAppVersion + " NASDKAPI Android")
+				.setHeader("Accept-Language", "en-US")
+				.setHeader("Content-Type", "application/x-www-form-urlencoded")
+				.setHeader("Accept", "application/json")
+				.setHeader("Accept-Encoding", "gzip,deflate,br")
+				.build();
+
+		SessionTokenResponse response = sendRequestAndParseGzippedJson(request, SessionTokenResponse.class);
+		return response != null ? response.session_token : null;
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	private static class SessionTokenResponse {
+		private String code;
+		private String session_token;
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/SplatoonCookieRetriever.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/SplatoonCookieRetriever.java
@@ -1,0 +1,47 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+public class SplatoonCookieRetriever extends AuthenticatorBase {
+	public String getSplatoonCookie(String splatoonAccessToken) {
+		String address = "https://app.splatoon2.nintendo.net/?lang=en-US";
+
+		URI uri = URI.create(address);
+
+		HttpRequest request = HttpRequest.newBuilder()
+				.GET()
+				.uri(uri)
+				.setHeader("X-IsAppAnalyticsOptedIn", "false")
+				.setHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+				.setHeader("Accept-Encoding", "gzip,deflate")
+				.setHeader("X-GameWebToken", splatoonAccessToken)
+				.setHeader("Accept-Language", "en-US")
+				.setHeader("X-IsAnalyticsOptedIn", "false")
+				.setHeader("DNT", "0")
+				.setHeader("User-Agent", "Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.61 Mobile Safari/537.36")
+				.setHeader("X-Requested-With", "com.nintendo.znca")
+				.build();
+
+		return sendRequestAndGetIksmSessionCookie(request);
+	}
+
+	private String sendRequestAndGetIksmSessionCookie(HttpRequest request) {
+		try {
+			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+			if (response.statusCode() < 300) {
+				List<String> foundHeaders = response.headers().allValues("Set-Cookie");
+				foundHeaders.forEach(System.out::println);
+				return foundHeaders.stream().filter(h -> h.contains("iksm_session")).findFirst().orElse("");
+			}
+		} catch (IOException | InterruptedException e) {
+			e.printStackTrace();
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/SplatoonTokenRetriever.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/SplatoonTokenRetriever.java
@@ -1,0 +1,123 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model.FParamLoginResult;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model.NsoAppLoginData;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model.UserInfo;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+
+public class SplatoonTokenRetriever extends AuthenticatorBase {
+	public String doSplatoonAppLogin(UserInfo userInfo, FParamLoginResult fParamLoginResult) {
+		String address = "https://api-lp1.znc.srv.nintendo.net/v1/Account/Login";
+
+		URI uri = URI.create(address);
+
+		String body = "";
+		try {
+			body = mapper.writeValueAsString(new AccountLoginBody(new AccountLoginBody.LoginParameter(
+					fParamLoginResult.getResult().getF(),
+					fParamLoginResult.getResult().getP1(),
+					fParamLoginResult.getResult().getP2(),
+					fParamLoginResult.getResult().getP3(),
+					userInfo.getCountry(),
+					userInfo.getBirthday(),
+					userInfo.getLanguage()
+			)));
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+		}
+
+		HttpRequest request = HttpRequest.newBuilder()
+				.POST(HttpRequest.BodyPublishers.ofString(body))
+				.uri(uri)
+				.setHeader("Accept-Language", "en-US")
+				.setHeader("User-Agent", "com.nintendo.znca/" + nsoAppVersion + " (Android/7.1.2)")
+				.setHeader("Accept", "application/json")
+				.setHeader("X-ProductVersion", nsoAppVersion)
+				.setHeader("Content-Type", "application/json; charset=utf-8")
+				.setHeader("Authorization", "Bearer")
+				.setHeader("X-Platform", "Android")
+				.setHeader("Accept-Encoding", "gzip")
+				.build();
+
+		NsoAppLoginData result = sendRequestAndParseGzippedJson(request, NsoAppLoginData.class);
+		return result != null ? result.getResult().getWebApiServerCredential().getAccessToken() : "";
+	}
+
+	public String getSplatoonAccessToken(String gameWebToken, FParamLoginResult FParamLoginResult) {
+		String address = "https://api-lp1.znc.srv.nintendo.net/v2/Game/GetWebServiceToken";
+
+		URI uri = URI.create(address);
+
+		String body = "";
+		try {
+			body = mapper.writeValueAsString(new SplatoonTokenRequestBody(new SplatoonTokenRequestBody.LoginParameter(
+					5741031244955648L,
+					FParamLoginResult.getResult().getF(),
+					FParamLoginResult.getResult().getP1(),
+					FParamLoginResult.getResult().getP2(),
+					FParamLoginResult.getResult().getP3()
+			)));
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+		}
+
+		HttpRequest request = HttpRequest.newBuilder()
+				.POST(HttpRequest.BodyPublishers.ofString(body))
+				.uri(uri)
+				.setHeader("User-Agent", "com.nintendo.znca/" + nsoAppVersion + " (Android/7.1.2)")
+				.setHeader("Accept", "application/json")
+				.setHeader("X-ProductVersion", nsoAppVersion)
+				.setHeader("Content-Type", "application/json; charset=utf-8")
+				.setHeader("Authorization", String.format("Bearer %s", gameWebToken))
+				.setHeader("X-Platform", "Android")
+				.setHeader("Accept-Encoding", "gzip")
+				.build();
+
+		NsoAppLoginData result = sendRequestAndParseGzippedJson(request, NsoAppLoginData.class);
+		return result != null ? result.getResult().getAccessToken() : "";
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	private static class AccountLoginBody {
+		private LoginParameter parameter;
+
+		@Data
+		@NoArgsConstructor
+		@AllArgsConstructor
+		private static class LoginParameter {
+			private String f;
+			private String naIdToken;
+			private String timestamp;
+			private String requestId;
+			private String naCountry;
+			private String naBirthday;
+			private String language;
+		}
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	private static class SplatoonTokenRequestBody {
+		private LoginParameter parameter;
+
+		@Data
+		@NoArgsConstructor
+		@AllArgsConstructor
+		private static class LoginParameter {
+			long id;
+			String f;
+			String registrationToken;
+			String timestamp;
+			String requestId;
+		}
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/UserInfoRetriever.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/UserInfoRetriever.java
@@ -1,0 +1,26 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication;
+
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model.UserInfo;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+
+public class UserInfoRetriever extends AuthenticatorBase {
+	public UserInfo getUserInfo(String accountAccessToken) {
+		String address = "https://api.accounts.nintendo.com/2.0.0/users/me";
+
+		URI uri = URI.create(address);
+
+		HttpRequest request = HttpRequest.newBuilder()
+				.GET()
+				.uri(uri)
+				.setHeader("User-Agent", "OnlineLounge/" + nsoAppVersion + " NASDKAPI Android")
+				.setHeader("Accept-Language", "en-US")
+				.setHeader("Accept", "application/json")
+				.setHeader("Authorization", String.format("Bearer %s", accountAccessToken))
+				.setHeader("Accept-Encoding", "gzip")
+				.build();
+
+		return sendRequestAndParseGzippedJson(request, UserInfo.class);
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/model/AuthenticationData.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/model/AuthenticationData.java
@@ -1,0 +1,17 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthenticationData {
+	private String nickname;
+	private String cookie;
+	private Instant cookieExpiresAt;
+	private String sessionToken;
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/model/FParamLoginResult.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/model/FParamLoginResult.java
@@ -1,0 +1,22 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FParamLoginResult {
+	private FParamResult result;
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class FParamResult {
+		private String f;
+		private String p1;
+		private String p2;
+		private String p3;
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/model/NsoAppLoginData.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/model/NsoAppLoginData.java
@@ -1,0 +1,32 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NsoAppLoginData {
+	private NsoLoginResult result;
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class NsoLoginResult {
+		private NsoAccessToken webApiServerCredential;
+		private String accessToken;
+
+		@JsonIgnoreProperties(ignoreUnknown = true)
+		@Data
+		@NoArgsConstructor
+		@AllArgsConstructor
+		public static class NsoAccessToken {
+			private int expiresIn;
+			private String accessToken;
+		}
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/model/UserInfo.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/authentication/model/UserInfo.java
@@ -1,0 +1,17 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.authentication.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfo {
+	private String nickname;
+	private String country;
+	private String birthday;
+	private String language;
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/results/ResultsExporter.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/results/ResultsExporter.java
@@ -137,14 +137,18 @@ public class ResultsExporter {
 	}
 
 	public void start(Account account) {
-		discordBot.sendPrivateMessage(account.getDiscordId(), "starting the stream!");
-		statistics.reset();
-		extendedStatisticsExporter.start(Instant.now(), account.getId());
+		if (account != null) {
+			discordBot.sendPrivateMessage(account.getDiscordId(), "starting the stream!");
+			statistics.reset();
+			extendedStatisticsExporter.start(Instant.now(), account.getId());
+		}
 	}
 
 	public void stop(Account account) {
-		discordBot.sendPrivateMessage(account.getDiscordId(), "stopping the stream!");
-		stop();
+		if (account != null) {
+			discordBot.sendPrivateMessage(account.getDiscordId(), "stopping the stream!");
+			stop();
+		}
 	}
 
 	public void stop() {

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/results/ResultsExporter.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/results/ResultsExporter.java
@@ -22,12 +22,12 @@ import tv.strohi.twitch.strohkoenigbot.utils.ExceptionSender;
 import tv.strohi.twitch.strohkoenigbot.utils.SplatoonMatchColorComponent;
 
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
+
+import static tv.strohi.twitch.strohkoenigbot.utils.TimezoneUtils.timeOfTimezoneIsBetweenTimes;
 
 @Component
 public class ResultsExporter {
@@ -273,11 +273,6 @@ public class ResultsExporter {
 	}
 
 	private boolean isDirectlyPastMidnight(String timezone) {
-		if (timezone != null && !timezone.isBlank()) {
-			ZonedDateTime time = Instant.now().atZone(ZoneId.of(timezone));
-			return time.getHour() == 0 && time.getMinute() >= 7 && time.getMinute() <= 8;
-		}
-
-		return false;
+		return timeOfTimezoneIsBetweenTimes(timezone, 0, 8, 0, 12);
 	}
 }

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/results/StatsExporter.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/results/StatsExporter.java
@@ -17,6 +17,7 @@ import tv.strohi.twitch.strohkoenigbot.splatoonapi.model.SplatNetStatPage;
 import tv.strohi.twitch.strohkoenigbot.splatoonapi.rotations.StagesExporter;
 import tv.strohi.twitch.strohkoenigbot.splatoonapi.utils.RequestSender;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -76,6 +77,7 @@ public class StatsExporter {
 
 		List<Account> accounts = accountRepository.findAll().stream()
 				.filter(a -> a.getSplatoonCookie() != null && !a.getSplatoonCookie().isBlank())
+				.filter(a -> a.getSplatoonCookieExpiresAt() != null && Instant.now().isBefore(a.getSplatoonCookieExpiresAt()))
 				.filter(a -> a.getTimezone() != null && !a.getTimezone().isBlank())
 				.filter(a -> timeOfTimezoneIsBetweenTimes(a.getTimezone(), 0, 2, 0, 4))
 				.collect(Collectors.toList());

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/results/StatsExporter.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/results/StatsExporter.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static tv.strohi.twitch.strohkoenigbot.utils.TimezoneUtils.timeOfTimezoneIsBetweenTimes;
+
 @Component
 public class StatsExporter {
 	private final Logger logger = LogManager.getLogger(this.getClass().getSimpleName());
@@ -68,25 +70,32 @@ public class StatsExporter {
 		this.splatoonStatsLoader = splatoonStatsLoader;
 	}
 
-	@Scheduled(cron = "0 47 4 * * *")
+	@Scheduled(cron = "0 3 * * * *")
 	public void refreshStageAndWeaponStats() {
 		logger.info("loading stage and weapon stats");
 
-		Account account = accountRepository.findAll().stream()
-				.filter(Account::getIsMainAccount)
-				.findFirst()
-				.orElse(new Account());
+		List<Account> accounts = accountRepository.findAll().stream()
+				.filter(a -> a.getSplatoonCookie() != null && !a.getSplatoonCookie().isBlank())
+				.filter(a -> a.getTimezone() != null && !a.getTimezone().isBlank())
+				.filter(a -> timeOfTimezoneIsBetweenTimes(a.getTimezone(), 0, 2, 0, 4))
+				.collect(Collectors.toList());
 
+		for (Account account : accounts) {
+			refreshStatsForAccount(account);
+		}
+	}
+
+	public void refreshStatsForAccount(Account account) {
 		SplatNetStatPage splatNetStatPage = splatoonStatsLoader.querySplatoonApiForAccount(account, "/api/records", SplatNetStatPage.class);
 
-		logger.info("refreshing weapon stats");
+		logger.info("refreshing weapon stats for account {}", account.getId());
 		refreshWeaponStats(account.getId(), splatNetStatPage.getRecords().getWeapon_stats().values().stream()
 				.sorted((w1, w2) -> -Integer.compare(w1.getWin_count(), w2.getWin_count()))
 				.collect(Collectors.toList())
 		);
-		logger.info("refreshing stage stats");
+		logger.info("refreshing stage stats for account {}", account.getId());
 		refreshStageStats(account.getId(), new ArrayList<>(splatNetStatPage.getRecords().getStage_stats().values()));
-		logger.info("finished refresh");
+		logger.info("finished refresh for account {}", account.getId());
 	}
 
 	private void refreshWeaponStats(long accountId, List<SplatNetStatPage.SplatNetRecords.SplatNetWeaponStats> loadedWeaponStats) {

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/rotations/RotationWatcher.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/rotations/RotationWatcher.java
@@ -100,39 +100,43 @@ public class RotationWatcher {
 	public void sendDiscordNotifications() {
 		refreshStages();
 
-		if (Arrays.stream(stages.getGachi()).allMatch(s -> s.getEndTimeAsInstant().isAfter(Instant.now().plus(1, ChronoUnit.HOURS)))) {
-			sendDiscordMessageToChannel(DiscordChannelDecisionMaker.getTurfWarChannel(),
-					formatDiscordMessage(stages.getRegular()),
-					stages.getRegular()[0].getStage_a().getImage(),
-					stages.getRegular()[0].getStage_b().getImage());
+		if (stages != null) {
+			if (Arrays.stream(stages.getGachi()).allMatch(s -> s.getEndTimeAsInstant().isAfter(Instant.now().plus(1, ChronoUnit.HOURS)))) {
+				sendDiscordMessageToChannel(DiscordChannelDecisionMaker.getTurfWarChannel(),
+						formatDiscordMessage(stages.getRegular()),
+						stages.getRegular()[0].getStage_a().getImage(),
+						stages.getRegular()[0].getStage_b().getImage());
 
-			sendDiscordMessageToChannel(DiscordChannelDecisionMaker.getRankedChannel(),
-					formatDiscordMessage(stages.getGachi()),
-					stages.getGachi()[0].getStage_a().getImage(),
-					stages.getGachi()[0].getStage_b().getImage());
+				sendDiscordMessageToChannel(DiscordChannelDecisionMaker.getRankedChannel(),
+						formatDiscordMessage(stages.getGachi()),
+						stages.getGachi()[0].getStage_a().getImage(),
+						stages.getGachi()[0].getStage_b().getImage());
 
-			sendDiscordMessageToChannel(DiscordChannelDecisionMaker.getLeagueChannel(),
-					formatDiscordMessage(stages.getLeague()),
-					stages.getLeague()[0].getStage_a().getImage(),
-					stages.getLeague()[0].getStage_b().getImage());
+				sendDiscordMessageToChannel(DiscordChannelDecisionMaker.getLeagueChannel(),
+						formatDiscordMessage(stages.getLeague()),
+						stages.getLeague()[0].getStage_a().getImage(),
+						stages.getLeague()[0].getStage_b().getImage());
 
-			if (stages.getRegular().length > 0 && !DiscordChannelDecisionMaker.isIsLocalDebug()) {
+				if (stages.getRegular().length > 0 && !DiscordChannelDecisionMaker.isIsLocalDebug()) {
 //			if (stages.getRegular().length > 0) {
-				sendDiscordNotificationsToUsers(stages.getRegular()[0]);
-				sendDiscordNotificationsToUsers(stages.getRegular()[stages.getRegular().length - 1]);
-			}
+					sendDiscordNotificationsToUsers(stages.getRegular()[0]);
+					sendDiscordNotificationsToUsers(stages.getRegular()[stages.getRegular().length - 1]);
+				}
 
-			if (stages.getGachi().length > 0 && !DiscordChannelDecisionMaker.isIsLocalDebug()) {
+				if (stages.getGachi().length > 0 && !DiscordChannelDecisionMaker.isIsLocalDebug()) {
 //			if (stages.getGachi().length > 0) {
-				sendDiscordNotificationsToUsers(stages.getGachi()[0]);
-				sendDiscordNotificationsToUsers(stages.getGachi()[stages.getGachi().length - 1]);
-			}
+					sendDiscordNotificationsToUsers(stages.getGachi()[0]);
+					sendDiscordNotificationsToUsers(stages.getGachi()[stages.getGachi().length - 1]);
+				}
 
-			if (stages.getLeague().length > 0 && !DiscordChannelDecisionMaker.isIsLocalDebug()) {
+				if (stages.getLeague().length > 0 && !DiscordChannelDecisionMaker.isIsLocalDebug()) {
 //			if (stages.getLeague().length > 0) {
-				sendDiscordNotificationsToUsers(stages.getLeague()[0]);
-				sendDiscordNotificationsToUsers(stages.getLeague()[stages.getLeague().length - 1]);
+					sendDiscordNotificationsToUsers(stages.getLeague()[0]);
+					sendDiscordNotificationsToUsers(stages.getLeague()[stages.getLeague().length - 1]);
+				}
 			}
+		} else {
+			logger.error("stages were null!");
 		}
 	}
 
@@ -186,12 +190,16 @@ public class RotationWatcher {
 
 			stages = stagesLoader.querySplatoonApiForAccount(account, "/api/schedules", SplatNetStages.class);
 
-			saveStagesInDatabase(stages.getRegular());
-			saveStagesInDatabase(stages.getGachi());
-			saveStagesInDatabase(stages.getLeague());
+			if (stages != null ) {
+				saveStagesInDatabase(stages.getRegular());
+				saveStagesInDatabase(stages.getGachi());
+				saveStagesInDatabase(stages.getLeague());
 
-			logger.info("finished stage loading");
-			logger.debug(stages);
+				logger.info("finished stage loading");
+				logger.debug(stages);
+			} else {
+				logger.error("stages were null!");
+			}
 		}
 	}
 

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/AuthenticatedHttpClientCreator.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/AuthenticatedHttpClientCreator.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import tv.strohi.twitch.strohkoenigbot.chatbot.spring.DiscordBot;
 import tv.strohi.twitch.strohkoenigbot.data.model.Account;
-import tv.strohi.twitch.strohkoenigbot.data.repository.ConfigurationRepository;
 import tv.strohi.twitch.strohkoenigbot.data.repository.AccountRepository;
 
 import java.net.http.HttpClient;
@@ -18,13 +17,6 @@ public class AuthenticatedHttpClientCreator {
 		this.accountRepository = accountRepository;
 	}
 
-	private ConfigurationRepository configurationRepository;
-
-	@Autowired
-	public void setConfigurationRepository(ConfigurationRepository configurationRepository) {
-		this.configurationRepository = configurationRepository;
-	}
-
 	private DiscordBot discordBot;
 
 	@Autowired
@@ -35,7 +27,7 @@ public class AuthenticatedHttpClientCreator {
 	public HttpClient createFor(Account account) {
 		return HttpClient.newBuilder()
 				.version(HttpClient.Version.HTTP_2)
-				.cookieHandler(SplatoonCookieHandler.of(account, accountRepository, configurationRepository, discordBot))
+				.cookieHandler(SplatoonCookieHandler.of(account, accountRepository, discordBot))
 				.build();
 	}
 }

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/DailyStatsSender.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/DailyStatsSender.java
@@ -240,7 +240,7 @@ public class DailyStatsSender {
 					.append(";").append(getNumber(weaponStats.getWins()) + getNumber(weaponStats.getDefeats()))
 					.append(";").append(getNumber(weaponStats.getWins()))
 					.append(";").append(getNumber(weaponStats.getDefeats()))
-					.append(";").append(String.format("%d%%", getNumber(weaponStats.getWins()) * 100 / (getNumber(weaponStats.getWins()) + getNumber(weaponStats.getDefeats()))))
+					.append(";").append(String.format("%d %%", getNumber(weaponStats.getWins()) * 100 / (getNumber(weaponStats.getWins()) + getNumber(weaponStats.getDefeats()))))
 					.append(";").append(yesterdayWins)
 					.append(";").append(yesterdayDefeats)
 					.append(";").append(String.format("%.1f", currentFlag))

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/DailyStatsSender.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/DailyStatsSender.java
@@ -79,60 +79,60 @@ public class DailyStatsSender {
 		c.add(Calendar.DAY_OF_YEAR, -1);
 		long startTime = c.toInstant().getEpochSecond(); //the midnight, that's the first second of the day.
 
-		Account account = accountRepository.findAll().stream()
-				.filter(Account::getIsMainAccount)
-				.findFirst()
-				.orElse(new Account());
-
-		List<Splatoon2Match> matches = matchRepository.findByAccountIdAndStartTimeGreaterThanEqualAndEndTimeLessThanEqual(account.getId(), startTime, endTime);
-		logger.info("found {} matches..", matches.size());
-
-		List<Splatoon2WeaponStats> weaponStats = weaponStatsRepository.findByTurfLessThanAndAccountId(100_000, account.getId());
-
-		long yesterdayPaint = matches.stream().map(m -> (long) m.getTurfGain()).reduce(0L, Long::sum);
-		long weaponCount = matches.stream().map(Splatoon2Match::getWeaponId).distinct().count();
-
-		List<Splatoon2WeaponStats> newRedBadgeWeaponStats = matches.stream()
-				.filter(m -> m.getTurfTotal() >= 100_000 && m.getTurfTotal() - m.getTurfGain() < 100_000)
-				.map(m -> weaponStatsRepository.findByWeaponIdAndAccountId(m.getWeaponId(), account.getId()).orElse(null))
-				.filter(Objects::nonNull)
-				.collect(Collectors.toList());
-		List<Splatoon2Weapon> newRedBadgeWeapons = newRedBadgeWeaponStats.stream()
-				.map(ws -> weaponRepository.findById(ws.getWeaponId()).orElse(null))
-				.filter(Objects::nonNull)
+		List<Account> accounts = accountRepository.findAll().stream()
+				.filter(Account::getShouldSendDailyStats)
+				.filter(a -> a.getSplatoonCookie() != null && !a.getSplatoonCookie().isBlank())
+				.filter(a -> a.getSplatoonCookieExpiresAt() != null && Instant.now().isBefore(a.getSplatoonCookieExpiresAt()))
+				.filter(a -> a.getTimezone() != null && !a.getTimezone().isBlank())
 				.collect(Collectors.toList());
 
-		long leftToPaint = weaponStats.stream().map(w -> 100_000 - w.getTurf()).reduce(0L, Long::sum);
-		double daysUntilGoalReached = leftToPaint / 40_000.0;
+		for (Account account : accounts) {
+			List<Splatoon2Match> matches = matchRepository.findByAccountIdAndStartTimeGreaterThanEqualAndEndTimeLessThanEqual(account.getId(), startTime, endTime);
+			logger.info("found {} matches..", matches.size());
 
-		double dailyPaintUntilS3 = getDailyPaintUntilSplatoon3(leftToPaint);
+			List<Splatoon2WeaponStats> weaponStats = weaponStatsRepository.findByTurfLessThanAndAccountId(100_000, account.getId());
 
-		String message = String.format("Yesterday, I painted a total sum of **%d** points on **%d** different weapons.\n\nI still need to paint a total of **%d** points on **%d** different weapons.\nThat's **%.2f days** if I paint **40k points** every day (or **%.2f** paint per day until 9/9).", yesterdayPaint, weaponCount, leftToPaint, weaponStats.size(), daysUntilGoalReached, dailyPaintUntilS3);
+			long yesterdayPaint = matches.stream().map(m -> (long) m.getTurfGain()).reduce(0L, Long::sum);
+			long weaponCount = matches.stream().map(Splatoon2Match::getWeaponId).distinct().count();
 
-		if (newRedBadgeWeapons.size() > 0) {
-			StringBuilder builder = new StringBuilder(message);
-			builder.append("\n\nThese **").append(newRedBadgeWeapons.size()).append("** weapons got their red badge yesterday:");
+			List<Splatoon2WeaponStats> newRedBadgeWeaponStats = matches.stream()
+					.filter(m -> m.getTurfTotal() >= 100_000 && m.getTurfTotal() - m.getTurfGain() < 100_000)
+					.map(m -> weaponStatsRepository.findByWeaponIdAndAccountId(m.getWeaponId(), account.getId()).orElse(null))
+					.filter(Objects::nonNull)
+					.collect(Collectors.toList());
+			List<Splatoon2Weapon> newRedBadgeWeapons = newRedBadgeWeaponStats.stream()
+					.map(ws -> weaponRepository.findById(ws.getWeaponId()).orElse(null))
+					.filter(Objects::nonNull)
+					.collect(Collectors.toList());
 
-			for (Splatoon2Weapon weapon : newRedBadgeWeapons) {
-				builder.append("\n- **").append(weapon.getName()).append("** (").append(weapon.getSubName()).append(", ").append(weapon.getSpecialName()).append(")");
+			String message = String.format("Yesterday, you painted a total sum of **%d** points on **%d** different weapons in **%d** matches.", yesterdayPaint, weaponCount, matches.size());
+
+			if (newRedBadgeWeapons.size() > 0) {
+				StringBuilder builder = new StringBuilder(message);
+				builder.append("\n\nYou received a red badge on these **").append(newRedBadgeWeapons.size()).append("** weapons yesterday:");
+
+				for (Splatoon2Weapon weapon : newRedBadgeWeapons) {
+					builder.append("\n- **").append(weapon.getName()).append("** (").append(weapon.getSubName()).append(", ").append(weapon.getSpecialName()).append(")");
+				}
+
+				message = builder.toString();
 			}
 
-			message = builder.toString();
-		}
+			if (matches.size() > 0) {
+				String weaponStatsCsv = createWeaponStatsCsv(account.getId(), matches);
 
-		if (matches.size() > 0) {
-			String weaponStatsCsv = createWeaponStatsCsv(account.getId(), matches);
+				Date yesterday = c.getTime();
+				DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+				String strDate = dateFormat.format(yesterday);
 
-			Date yesterday = c.getTime();
-			DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-			String strDate = dateFormat.format(yesterday);
-
-			discordBot.sendPrivateMessageWithAttachment(discordBot.loadUserIdFromDiscordServer("strohkoenig#8058"),
-					message,
-					String.format("%s.csv", strDate),
-					new ByteArrayInputStream(weaponStatsCsv.getBytes(StandardCharsets.UTF_8)));
-		} else {
-			discordBot.sendPrivateMessage(discordBot.loadUserIdFromDiscordServer("strohkoenig#8058"), message);
+				discordBot.sendPrivateMessageWithAttachment(discordBot.loadUserIdFromDiscordServer("strohkoenig#8058"),
+						message,
+						String.format("%s.csv", strDate),
+						new ByteArrayInputStream(weaponStatsCsv.getBytes(StandardCharsets.UTF_8)));
+			} else {
+				message = String.format("%s\nYou won't receive a CSV today as you didn't play online and nothing has changed since the last time you received a CSV.", message);
+				discordBot.sendPrivateMessage(discordBot.loadUserIdFromDiscordServer("strohkoenig#8058"), message);
+			}
 		}
 	}
 
@@ -146,7 +146,7 @@ public class DailyStatsSender {
 	}
 
 	private String createWeaponStatsCsv(long accountId, List<Splatoon2Match> yesterdayMatches) {
-		StringBuilder builder = new StringBuilder("Name;Class;Sub;Special;Total Paint;Paint Left;Painted Yesterday;Matches;Wins;Defeats;Win rate;Wins delta;Defeats delta;Paint per Match;Current Flag"
+		StringBuilder builder = new StringBuilder("Name;Class;Sub;Special;Total Paint;Painted Yesterday;Paint per Match;Matches;Wins;Defeats;Win rate;Wins delta;Defeats delta;Current Flag"
 //				+ ";Current Flag delta"
 				+ ";Max Flag"
 //				+ ";Max Flag delta"
@@ -232,15 +232,15 @@ public class DailyStatsSender {
 					.append(";").append(weapon.getSubName())
 					.append(";").append(weapon.getSpecialName())
 					.append(";").append(weaponStats.getTurf())
-					.append(";").append(100_000 - weaponStats.getTurf() > 0 ? 100_000 - weaponStats.getTurf() : 0)
+//					.append(";").append(100_000 - weaponStats.getTurf() > 0 ? 100_000 - weaponStats.getTurf() : 0)
 					.append(";").append(yesterdayPaint)
+					.append(";").append(String.format("%.2f", calculateAvgPaint(weaponStats.getTurf(), getNumber(weaponStats.getWins()) + getNumber(weaponStats.getDefeats()))))
 					.append(";").append(getNumber(weaponStats.getWins()) + getNumber(weaponStats.getDefeats()))
 					.append(";").append(getNumber(weaponStats.getWins()))
 					.append(";").append(getNumber(weaponStats.getDefeats()))
 					.append(";").append(String.format("%d%%", getNumber(weaponStats.getWins()) * 100 / (getNumber(weaponStats.getWins()) + getNumber(weaponStats.getDefeats()))))
 					.append(";").append(yesterdayWins)
 					.append(";").append(yesterdayDefeats)
-					.append(";").append(String.format("%.2f", calculateAvgPaint(weaponStats.getTurf(), getNumber(weaponStats.getWins()) + getNumber(weaponStats.getDefeats()))))
 					.append(";").append(String.format("%.1f", currentFlag))
 //					.append(";").append(String.format("%.1f", currentFlag - currentFlagDelta))
 					.append(";").append(String.format("%.1f", maxFlag))

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/DailyStatsSender.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/DailyStatsSender.java
@@ -68,7 +68,7 @@ public class DailyStatsSender {
 		this.matchRepository = matchRepository;
 	}
 
-	@Scheduled(cron = "0 10 0 * * *")
+	@Scheduled(cron = "0 15 0 * * *")
 //	@Scheduled(cron = "0 * * * * *")
 	public void sendDailyStatsToDiscord() {
 		Calendar c = new GregorianCalendar();

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/DailyStatsSender.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/DailyStatsSender.java
@@ -28,6 +28,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.time.temporal.ChronoUnit.DAYS;
+import static tv.strohi.twitch.strohkoenigbot.utils.TimezoneUtils.timeOfTimezoneIsBetweenTimes;
 
 @Component
 public class DailyStatsSender {
@@ -84,6 +85,7 @@ public class DailyStatsSender {
 				.filter(a -> a.getSplatoonCookie() != null && !a.getSplatoonCookie().isBlank())
 				.filter(a -> a.getSplatoonCookieExpiresAt() != null && Instant.now().isBefore(a.getSplatoonCookieExpiresAt()))
 				.filter(a -> a.getTimezone() != null && !a.getTimezone().isBlank())
+				.filter(a -> timeOfTimezoneIsBetweenTimes(a.getTimezone(), 0, 10, 0, 20))
 				.collect(Collectors.toList());
 
 		for (Account account : accounts) {

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/RequestSender.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/RequestSender.java
@@ -5,7 +5,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import tv.strohi.twitch.strohkoenigbot.chatbot.spring.DiscordBot;
 import tv.strohi.twitch.strohkoenigbot.data.model.Account;
+import tv.strohi.twitch.strohkoenigbot.splatoonapi.utils.model.CookieRefreshException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -25,6 +27,13 @@ public class RequestSender {
 	@Autowired
 	public void setClientCreator(AuthenticatedHttpClientCreator clientCreator) {
 		this.clientCreator = clientCreator;
+	}
+
+	private DiscordBot discordBot;
+
+	@Autowired
+	public void setDiscordBot(DiscordBot discordBot) {
+		this.discordBot = discordBot;
 	}
 
 	private final ObjectMapper mapper = new ObjectMapper();
@@ -79,10 +88,15 @@ public class RequestSender {
 				logger.info(response);
 			}
 		} catch (IOException | InterruptedException e) {
-			logger.error("exception while sending request");
-			logger.error("response body: '{}'", body);
+			if (e instanceof IOException && e.getCause() != null && e.getCause() instanceof CookieRefreshException) {
+				discordBot.sendPrivateMessage(account.getDiscordId(), "**ERROR** your cookie to access to splatnet became outdated, I cannot access splatnet anymore.\nPlease provide new login credentials by using the **!splatoon register** command.");
+				logger.error("The cookie for account with id {} wasn't valid anymore and no session token has been set!", account.getId());
+			} else {
+				logger.error("exception while sending request");
+				logger.error("response body: '{}'", body);
 
-			logger.error(e);
+				logger.error(e);
+			}
 		}
 
 		return null;

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/RequestSender.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/RequestSender.java
@@ -89,7 +89,7 @@ public class RequestSender {
 			}
 		} catch (IOException | InterruptedException e) {
 			if (e instanceof IOException && e.getCause() != null && e.getCause() instanceof CookieRefreshException) {
-				discordBot.sendPrivateMessage(account.getDiscordId(), "**ERROR** your cookie to access to splatnet became outdated, I cannot access splatnet anymore.\nPlease provide new login credentials by using the **!splatoon register** command.");
+				discordBot.sendPrivateMessage(account.getDiscordId(), "**ERROR** your cookie to access to splatnet became outdated, I cannot access splatnet anymore.\nPlease provide new login credentials by using the **!splatoon2 register** command.");
 				logger.error("The cookie for account with id {} wasn't valid anymore and no session token has been set!", account.getId());
 			} else {
 				logger.error("exception while sending request");

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/model/CookieRefreshException.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/model/CookieRefreshException.java
@@ -1,0 +1,15 @@
+package tv.strohi.twitch.strohkoenigbot.splatoonapi.utils.model;
+
+import lombok.*;
+
+import java.io.IOException;
+
+@Getter
+@Setter
+public class CookieRefreshException extends IOException {
+	private long AccountId;
+
+	public CookieRefreshException(long accountId, String message) {
+		super(message);
+	}
+}

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/model/CookieRefreshException.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/splatoonapi/utils/model/CookieRefreshException.java
@@ -7,9 +7,10 @@ import java.io.IOException;
 @Getter
 @Setter
 public class CookieRefreshException extends IOException {
-	private long AccountId;
+	private long accountId;
 
 	public CookieRefreshException(long accountId, String message) {
 		super(message);
+		this.accountId = accountId;
 	}
 }

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/utils/DiscordAccountLoader.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/utils/DiscordAccountLoader.java
@@ -26,7 +26,7 @@ public class DiscordAccountLoader {
 		Account account = accountRepository.findByDiscordIdOrderById(discordId).stream().findFirst().orElse(null);
 
 		if (account == null) {
-			account = new Account(0L, discordId, null, null, null, false, null, null, null);
+			account = new Account(0L, discordId, null, null,null, null, null, false, null, false, 0);
 			account = accountRepository.save(account);
 
 			discordBot.sendPrivateMessage(discordId, "Hi! Nice to meet you!");

--- a/src/main/java/tv/strohi/twitch/strohkoenigbot/utils/TimezoneUtils.java
+++ b/src/main/java/tv/strohi/twitch/strohkoenigbot/utils/TimezoneUtils.java
@@ -1,0 +1,19 @@
+package tv.strohi.twitch.strohkoenigbot.utils;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class TimezoneUtils {
+	private TimezoneUtils() {
+	}
+
+	public static boolean timeOfTimezoneIsBetweenTimes(String timezone, int startHour, int startMinute, int endHour, int endMinute) {
+		if (timezone != null && !timezone.isBlank()) {
+			ZonedDateTime time = Instant.now().atZone(ZoneId.of(timezone));
+			return time.getHour() >= startHour &&time.getHour() <= endHour && time.getMinute() >= startMinute && time.getMinute() <= endMinute;
+		}
+
+		return false;
+	}
+}

--- a/src/main/resources/db/changelog/db.changelog-master.json
+++ b/src/main/resources/db/changelog/db.changelog-master.json
@@ -3227,6 +3227,48 @@
           }
         ]
       }
+    },
+    {
+      "changeSet": {
+        "id": "27",
+        "author": "strohkoenig",
+        "changes": [
+          {
+            "addColumn": {
+              "columns": [
+                {
+                  "column": {
+                    "name": "splatoon_nickname",
+                    "position": 5,
+                    "type": "varchar(50)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "splatoon_session_token",
+                    "position": 6,
+                    "type": "varchar(500)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "rate_limit_number",
+                    "type": "int",
+                    "defaultValueComputed": "0"
+                  }
+                }
+              ],
+              "tableName": "account"
+            }
+          },
+          {
+            "dropColumn": {
+              "columnName": "current_step",
+              "tableName": "account"
+            }
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
- include s2s cookie generation method
- add action to generate cookie
- add action to activate daily stat sending
- change results exporter so that it saves the matches of all accounts once per hour
- change results exporter so that it only saves the matches of main accounts once every ten minutes
- change daily stats sender so that it sends to all accounts it need to send to
- change results exporter so that it refreshes results shortly before sending daily stats
- change stats exporter so that it refreshes stats shortly before sending daily stats
- do not add paint left for 100k to csv anymore - I won't reach that goal anyways qwq
- smaller bug fixes
- smaller refactorings